### PR TITLE
Let qparent and qapplied work for detached HEAD

### DIFF
--- a/git-qapplied
+++ b/git-qapplied
@@ -11,9 +11,11 @@ PATH="$(dirname $0):$PATH"
 
 if [[ "$1" != "" ]]; then
   branch="$1"
+  branchName="$1"
 else
-  branch="$(git branch | grep '^\*' | sed 's/^\* //')"
+  branch="HEAD"
+  branchName="$(git branch | grep '^\*' | sed 's/^\* //')"
 fi
 
-echo "Branch $branch (downstream from $(git tracks -d $branch))"
+echo "Branch $branchName (downstream from $(git tracks -d $branch))"
 git log --reverse --date-order --pretty=oneline --abbrev-commit "$(git qparent "$branch")".."$branch"

--- a/git-tracks
+++ b/git-tracks
@@ -24,7 +24,7 @@ fi
 shift
 
 if [[ "$1" == "" ]]; then
-  branch=$(git symbolic-ref HEAD) || exit $?
+  branch=$(git rev-parse --symbolic-full-name HEAD) || exit $?
   branch=${branch##refs/heads/}
 else
   branch="$1"


### PR DESCRIPTION
Let the command "git qparrent" and "git qapplied" work even when your are in a detached HEAD.
Ex:
  git checkout SOME_BRANCH^
  git qparrent
  git qapplied
