### PR TITLE
Use separate patch for try syntax

### DIFF
--- a/git-push-to-try
+++ b/git-push-to-try
@@ -41,8 +41,7 @@ fi
 
 git-push-to-hg $tip_cmd "$hg_repo" "$revs"
 
-commit_msg=$(hg log -R "$hg_repo" -l1 --template '{desc}')
-hg_cmd qref -sl <(echo "try: $@ $commit_msg")
+hg_cmd qnew try -l <(echo "try: $@")
 echo "try: $@"
 
 hg -R "$hg_repo" push -f ssh://hg.mozilla.org/try


### PR DESCRIPTION
I tend to run "git push-to-try ..." and then simultaneously post to Bugzilla using the patches in the hg repo's git-temp queue.

However, this approach currently breaks down a bit, because git push-to-try mangles the commit message of the last patch to throw in the try syntax at the front, which then displeased the sheriffs when I unknowingly left this format in my uploaded patch. 

This changes moves the try syntax to it's own empty patch, leaving the commit messages of actual code patches alone.
