### PR TITLE
Use patch file name if commit message is empty

### DIFF
--- a/hg-patch-to-git-patch
+++ b/hg-patch-to-git-patch
@@ -39,6 +39,9 @@ def hg_patch_to_git_patch(hg_patch_file):
             break
         commit_msg.append(hg_patch[i]) 
 
+    if len(commit_msg) == 1 and not commit_msg[0].strip():
+        commit_msg[0] = hg_patch_file.name
+
     if len(commit_msg) > 1 and not commit_msg[1].strip():
         del commit_msg[1]
 


### PR DESCRIPTION
When convert HG patches, you may have some with no commit messages. (This happened to me when converting MQ patches.)

Here we opt to use the name of the patch file in that case, which resembles the behavior of "hg qseries" for MQ.
