### PR TITLE
Remove quotes around user name

### DIFF
--- a/git-patch-to-hg-patch
+++ b/git-patch-to-hg-patch
@@ -19,7 +19,7 @@ r"""Git format-patch to hg importable patch.
 import sys
 import re
 import fileinput
-import email, email.parser, email.header
+import email, email.parser, email.header, email.utils
 import math
 from cStringIO import StringIO
 from itertools import takewhile
@@ -65,9 +65,10 @@ def clean_header(hdr_string):
 def process(git_patch_file):
   parser = email.parser.Parser()
   msg = parser.parse(git_patch_file)
+  parsed_from = email.utils.parseaddr(clean_header(msg['From']))
 
   return '\n'.join(['# HG changeset patch',
-                    '# User ' + clean_header(msg['From']),
+                    '# User %s <%s>' % parsed_from,
                     '',
                     clean_header(msg['subject']),
                     '',


### PR DESCRIPTION
The current version of `git-patch-to-hg-patch` leaves quotes around the user name part of the patch, but Mercurial doesn't use this when it makes its own patches natively, so the quotes show up in [commit logs](https://hg.mozilla.org/try/rev/9e088baa9ed0), [on TBPL](https://tbpl.mozilla.org/?tree=Fx-Team&rev=48a5e153526a), etc.

This strips out the quotes.
