### PR TITLE
Add date to hg git commits

### DIFF
--- a/hg-patch-to-git-patch
+++ b/hg-patch-to-git-patch
@@ -31,12 +31,11 @@ def hg_patch_to_git_patch(hg_patch_file):
 
         if line.startswith('# User '):
             author = line[len('# User '):]
-        if date_on_next_line:
-            date = line[1:].lstrip()
-            date_on_next_line = False
-        if line.startswith('# Date '):
+        elif line.startswith('# Date '):
             date = line[len('# Date '):]
             date_on_next_line = True
+        elif date_on_next_line:
+            date_on_next_line = False
 
     commit_msg = []
     for i in range(i, len(hg_patch)):


### PR DESCRIPTION
I needed to preserve dates so I added a few lines - thought I'd PR just in case this is useful and desired.

I don't understand how standard the hg patch format of having the date on two lines is - the times I looked at looked like this:

```
# HG changeset patch
# User Thomas Ballinger <thomasballinger@gmail.com>
# Date 1400296253 14400
#      Fri May 16 23:10:53 2014 -0400
# Node ID 8ce6b7f45d798a53e88548f402ef3b2e91bce599
# Parent  d549edd48fbe88ad3fc09d49a88bcf754c79963b
tests for line accessors

diff --git a/bpython/curtsiesfrontend/line.py b/bpython/curtsiesfrontend/line.py
...
```

I don't know if they always look like this, but this code assumes they do.
