### PR TITLE
Don't use a pager for 'git log' in git-push-to-hg

### DIFF
--- a/git-push-to-hg
+++ b/git-push-to-hg
@@ -71,7 +71,7 @@ if [[ "$(git log --merges $revs)" != "" ]]; then
 fi
 
 echo "On branch $(git branch | grep '^\*' | cut -f 2 -d ' ')."
-git log --reverse --date-order --pretty=oneline --abbrev-commit $revs
+git --no-pager log --reverse --date-order --pretty=oneline --abbrev-commit $revs
 
 git_status=$(git status --porcelain)
 if [[ "$git_status" != "" ]]; then


### PR DESCRIPTION
Since the output is meant to be printed to the terminal, and with non-standard pager settings it might not be (e.g. for me it opens an interactive less session).
