### PR TITLE
Generate hg patch files with 8 lines of context

### DIFF
--- a/git-push-to-hg
+++ b/git-push-to-hg
@@ -129,7 +129,7 @@ if [[ "$old_git" == 0 ]]; then
   git_format_quiet='--quiet'
 fi
 
-git format-patch $git_format_quiet -M -C -pk $revs -o ""$hg_repo"/.hg/patches-git-temp"
+git format-patch $git_format_quiet -M -C -U8 -pk $revs -o ""$hg_repo"/.hg/patches-git-temp"
 
 pushd ""$hg_repo"/.hg/patches-git-temp" > /dev/null
   find . -name '*.patch' | sort -g > series


### PR DESCRIPTION
Since I often upload the converted-to-hg patches to bugzilla, I want to have the preferred 8 lines of context in them.