### PR TITLE
Allow git-push-to-hg and git-push-to-try to work on Windows

### DIFF
--- a/git-patch-to-hg-patch
+++ b/git-patch-to-hg-patch
@@ -119,7 +119,8 @@ if __name__ == "__main__":
     # Process.
 
     if lines:
-      # Write them back to the same file.
-      f = open(filename, 'w')
+      # Write them back to the same file (and on Windows, ensure they just
+      # have \r line-endings instead of \r\n)
+      f = open(filename, 'wb')
       f.writelines(lines)
       f.close()

--- a/git-push-to-try
+++ b/git-push-to-try
@@ -41,8 +41,12 @@ fi
 
 git-push-to-hg $tip_cmd "$hg_repo" "$revs"
 
-hg_cmd qnew try -l <(echo "try: $@")
-echo "try: $@"
+# avoid using process substitution (ie, "-l <(echo ...)) because Windows.
+# Use a temp file instead.
+commit_msg_filename=$TMP/git-temp-$RANDOM-$$
+echo "try: $@" > $commit_msg_filename
+hg_cmd qnew try -l $commit_msg_filename
+rm $commit_msg_filename
 
 hg -R "$hg_repo" push -f ssh://hg.mozilla.org/try
 echo


### PR DESCRIPTION
This allows most of the tools to work on Windows:

* process substitution doesn't work on Windows, so I just created a temp file. It doesn't seem worth only doing this on Windows, so it's done everywhere.
* git-patch-to-hg-patch used to write patch files with \r\n line-endings, but this fix ensures \n line endings are used on Windows (and "b" mode should be ignored on other platforms)