### PR TITLE
Revert "Allow git-push-to-hg and git-push-to-try to work on Windows"

### DIFF
--- a/git-patch-to-hg-patch
+++ b/git-patch-to-hg-patch
@@ -119,8 +119,7 @@ if __name__ == "__main__":
     # Process.
 
     if lines:
-      # Write them back to the same file (and on Windows, ensure they just
-      # have \r line-endings instead of \r\n)
-      f = open(filename, 'wb')
+      # Write them back to the same file.
+      f = open(filename, 'w')
       f.writelines(lines)
       f.close()

--- a/git-push-to-try
+++ b/git-push-to-try
@@ -41,12 +41,8 @@ fi
 
 git-push-to-hg $tip_cmd "$hg_repo" "$revs"
 
-# avoid using process substitution (ie, "-l <(echo ...)) because Windows.
-# Use a temp file instead.
-commit_msg_filename=$TMP/git-temp-$RANDOM-$$
-echo "try: $@" > $commit_msg_filename
-hg_cmd qnew try -l $commit_msg_filename
-rm $commit_msg_filename
+hg_cmd qnew try -l <(echo "try: $@")
+echo "try: $@"
 
 hg -R "$hg_repo" push -f ssh://hg.mozilla.org/try
 echo


### PR DESCRIPTION
Reverts mozilla/moz-git-tools#31

This breaks things for me, as there's no $TMP defined.  I'll try to figure out another approach here.