### PR TITLE
Fix suppression of "PATCH" prefix in subject line.

### DIFF
--- a/git-patch-to-hg-patch
+++ b/git-patch-to-hg-patch
@@ -73,9 +73,10 @@ def process(git_patch_file):
     return
 
   parsed_from = email.utils.parseaddr(from_hdr)
-  nuke_prefix = "[PATCH] "
-  if commit_title.startswith(nuke_prefix):
-    commit_title = commit_title[len(nuke_prefix):]
+  nuke_prefix = r"\[PATCH( \d+/\d+)?\] "
+  match = re.match(nuke_prefix, commit_title)
+  if match:
+    commit_title = commit_title[match.end():]
 
   patch_body = msg.get_payload()
 


### PR DESCRIPTION
If more than one patch are generated by "git format-patch", the subject
lines will start with the pattern "[PATCH N/M] " instead of "[PATCH] ".
This causes the converted patch include the PATCH prefix.

We fix this by using a regular expression to match either "[PATCH] " or
"[PATCH N/M] " prefixes.