### PR TITLE
Fix tracks

### DIFF
--- a/git-tracks
+++ b/git-tracks
@@ -16,11 +16,16 @@
 # Based on http://serverfault.com/a/352236/38694
 
 if [[ "$1" == "-d" || "$1" == "--default" ]]; then
-  branch=HEAD
   use_default=1
+  shift
+else
+  use_default=0
+fi
+
+if [[ "$1" == "" ]]; then
+  branch=HEAD
 else
   branch=$1
-  use_default=0
 fi
 
 branchref=$(git rev-parse --symbolic-full-name $branch) || exit $?

--- a/git-tracks
+++ b/git-tracks
@@ -17,9 +17,18 @@
 
 if [[ "$1" == "-d" || "$1" == "--default" ]]; then
   branch=HEAD
+  use_default=1
 else
   branch=$1
+  use_default=0
 fi
 
 branchref=$(git rev-parse --symbolic-full-name $branch) || exit $?
-git for-each-ref --format='%(upstream:short)' $branchref
+remote=$(git for-each-ref --format='%(upstream:short)' $branchref)
+if [[ $remote != "" ]]; then
+  echo $remote
+elif [[ "$use_default" == 1 ]] && git rev-parse origin/master &>/dev/null; then
+  echo origin/master
+else
+  echo >&2 "Warning: Could not find a upstream for $branch"
+fi


### PR DESCRIPTION
This fixes a number of issues with pull request #35.

First, |git tracks -d| should use origin/master if there is no upstream for HEAD and origin/master is a valid branch.

Second, it should print out an error message if it fails.  I'm not sure if it will actually error out, but this at least restores the existing behavior.

Third, |git tracks| should use HEAD as the branch, rather than returning the upstream for every branch in the repository.

Third, |git tracks -d FOO| should use FOO as the branch rather than HEAD.