### PR TITLE
Restore previous patch queue after git-push-to-trychooser

### DIFF
--- a/git-push-to-trychooser
+++ b/git-push-to-trychooser
@@ -23,7 +23,10 @@ if [[ "$hg_repo" == "" ]]; then
   exit 255
 fi
 
+PREVIOUS_QUEUE=$(hg_cmd qqueue --active)
+
 git push-to-hg $@
 
 hg_cmd --config "extensions.trychooser=$TRYCHOOSER" trychooser
 hg_cmd -q qpop -a > /dev/null
+hg_cmd qqueue "$PREVIOUS_QUEUE"


### PR DESCRIPTION
Right now if you use git-push-to-trychooser and pass a Mercurial repo that you actively use, you're likely to be annoyed, because after the command runs that repo's current patch queue has been changed to the `git-temp` patch queue. This patch makes us remember the previous patch queue and change it back.