### PR TITLE
Use mercurial trychooser extension instead of bundled one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "git-bz-moz"]
 	path = git-bz-moz
 	url = https://github.com/mozilla/git-bz-moz.git
-[submodule "trychooser"]
-	path = trychooser
-	url = https://github.com/pbiggar/trychooser

--- a/README.markdown
+++ b/README.markdown
@@ -80,6 +80,11 @@ Usage: `git push-to-trychooser [-t/--tip] PATH_TO_HG_REPO [GIT_REVS]`
 The same as `git push-to-hg`, but also runs the interactive trychooser command
 before pushing the commits to try from the given hg repository.
 
+To use this, you must install the `trychooser` Mercurial extension from
+[its repository](https://bitbucket.org/sfink/trychooser). (There are some
+out-of-date versions of this extension floating around, so be sure to use this
+repository.)
+
 ## git-qparent
 
 Outputs the last common revision of the current branch and upstream.

--- a/git-push-to-trychooser
+++ b/git-push-to-trychooser
@@ -27,6 +27,6 @@ PREVIOUS_QUEUE=$(hg_cmd qqueue --active)
 
 git push-to-hg $@
 
-hg_cmd --config "extensions.trychooser=$TRYCHOOSER" trychooser
+hg_cmd trychooser
 hg_cmd -q qpop -a > /dev/null
 hg_cmd qqueue "$PREVIOUS_QUEUE"


### PR DESCRIPTION
Let's stop bundling the trychooser extension and just use the installed Mercurial one. It removes the maintenance burden of keeping the submodule up to date, and I don't really think we gain much from bundling it, since after all users still need Mercurial installed to use git-push-to-trychooser.