### PR TITLE
Explicitly use Python 2 in the shebang

### DIFF
--- a/git-patch-to-hg-patch
+++ b/git-patch-to-hg-patch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 r"""Git format-patch to hg importable patch.
 

--- a/git-remote-link
+++ b/git-remote-link
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """Output a link to a particular file+line in a remote repository.
 

--- a/hg-patch-to-git-patch
+++ b/hg-patch-to-git-patch
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 r'''Convert an hg-exported patch to a patch suitable for use by git am.
 


### PR DESCRIPTION
Some systems, notably Arch Linux, have decided that because they're bleeding edge, they're going to have /usr/bin/python set to Python 3 instead of Python 2. Of course, this wreaks havoc with applications that are (reasonably) expecting /usr/bin/python to be Python 2, but what can you do?

Therefore, explicitly request `python2` instead of `python` in the shebang line.