### PR TITLE
Add a wrapper for hg bzexport

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,20 @@ commit before pushing to bugzilla.
 don't use it for anything else, so I'm not sure which of the other features
 work with bugzilla.mozilla.org.)
 
+## git-bzexport
+
+Usage: `git bzexport [-t/--tip] PATH_TO_HG_REPO [GIT_REVS]`
+
+Push commits from git to bugzilla using the `bzexport` Mercurial extension from
+the [Mozilla version control tools repo](https://hg.mozilla.org/hgcustom/version-control-tools).
+
+The `bzexport` extension has some advantages over `bz attach` - for example, if
+multiple Bugzilla reviewers match the reviewer name you specify, `bzexport` will
+let you choose between them using a menu - so some users may prefer it.
+
+This command is implemented using `git-push-to-hg`, so see that command's
+documentation for more details on the argument syntax.
+
 ## git-new-workdir
 
 Create a new working directory based off an existing local git repository.

--- a/git-bzexport
+++ b/git-bzexport
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Uses push-to-hg to push revision(s) to the specified hg repository, and
+# then runs the hg "bzexport" command for uploading patches to Bugzilla.
+
+THIS_DIR=$(cd `dirname "$0"`; pwd)
+PATH="$THIS_DIR:$PATH"
+
+hg_cmd() {
+  # Don't suppress HG output since trychooser uses prompts
+  hg -R "$hg_repo" $@
+}
+
+hg_repo="$1"
+if [[ "$1" == "-t" || "$1" == "--tip" ]]; then
+  hg_repo="$2"
+fi
+
+if [[ "$hg_repo" == "" ]]; then
+  echo "Usage: $(basename "$0") [-t/--tip] path-to-hg-repo [git-revs]" 1>& 2
+  exit 255
+fi
+
+PREVIOUS_QUEUE=$(hg_cmd qqueue --active)
+
+git push-to-hg $@
+
+hg_cmd bzexport -e
+hg_cmd -q qpop -a > /dev/null
+hg_cmd qqueue $PREVIOUS_QUEUE


### PR DESCRIPTION
I think we should introduce a standard wrapper for `hg bzexport`, so users who prefer it can use it as part of a git-based workflow. (FWIW, I think it's *drastically* more usable and reliable than `git bz attach`.)