### PR TITLE
Avoid pushing other heads to try

### DIFF
--- a/git-push-to-try
+++ b/git-push-to-try
@@ -39,7 +39,7 @@ git-push-to-hg $tip_cmd "$hg_repo" "$revs"
 hg -R "$hg_repo" -q qnew try -m "try: $*" > /dev/null
 echo "try: $@"
 
-hg -R "$hg_repo" push -f ssh://hg.mozilla.org/try
+hg -R "$hg_repo" push -f -r tip ssh://hg.mozilla.org/try
 echo
 echo "https://treeherder.mozilla.org/#/jobs?repo=try&revision=$(hg -R "$hg_repo" log -l1 --template "{node|short}")"
 


### PR DESCRIPTION
I frequently use the hg repo that git-push-to-try is set up with to push patches to reviewboard, causing extra heads (in bookmarks) to float around in my repo. When I do git-push-to-try with something unrelated later on, all not previously pushed heads also get pushed and pollute Treeherder's UI (they're not actually part of the head being compiled).

This patch makes us push only tip after creating the trychooser patch in the hg repo, causing only it and its descendants to be pushed to try, no other heads.