### PR TITLE
Change exit status of git-new-workdir's usage command to 0

### DIFF
--- a/git-new-workdir
+++ b/git-new-workdir
@@ -6,9 +6,11 @@
 # This file is covered under GPLv2 (and /not/ later versions).  See
 # http://git.kernel.org/cgit/git/git.git/plain/COPYING
 
+# Modified by rwhogg on July 15, 2016
+
 usage () {
 	echo "usage:" $@
-	exit 127
+	exit 0
 }
 
 die () {


### PR DESCRIPTION
This changes the exit status of the usage command for `git-new-workdir` from 127 to 0.

With an exit status of 127, git outputs a warning message of the form:

```
fatal: 'new-workdir' appears to be a git command, but we were not
able to execute it. Maybe git-new-workdir is broken?
```