### PR TITLE
Add push-to-mozreview command.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,6 +92,19 @@ everything on that branch to try, use `--rev master..HEAD`.
 
 TRYCHOOSER\_PARAMS should be, e.g. `-b do -p all -u all -t none`.
 
+## git-push-to-mozreview
+
+Usage: `git push-to-review [-r/--rev REVISION_OR_RANGE] [-t/--tip] PATH_TO_HG_REPO`
+
+Push the commits `$(git merge-base HEAD $(git-tracks))..HEAD` (i.e. everything
+in the current branch that's not upstream) to mozreview, by way of the given hg
+repository.
+
+If `-r/--rev REVISION_OR_RANGE` is supplied, then push those commits to mozreview
+instead of `$(git merge-base HEAD $(git-tracks))..HEAD`. For example, if you are
+working on a feature branch that was branched off of master, and want to push
+everything on that branch to try, use `--rev master..HEAD`.
+
 ## git-push-to-trychooser
 
 Usage: `git push-to-trychooser [-t/--tip] PATH_TO_HG_REPO [GIT_REVS]`

--- a/git-push-to-mozreview
+++ b/git-push-to-mozreview
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Usage: git-push-to-mozreview [-t|--tip] [-r REVS|--rev REVS] HG_REPO
+
+set -e
+PATH=$(dirname $0):$PATH
+
+# Sigh, command-line parsing in bash is so much fun.
+
+while true; do
+  if [[ "$1" == "-t" || "$1" == "--tip" ]]; then
+    tip_cmd="--tip"
+    shift
+    continue
+  fi
+
+  if [[ "$1" == "-r" || "$1" == "--rev" ]]; then
+    revs="$2"
+    shift
+    shift
+    continue
+  fi
+
+  break
+done
+
+hg_repo=$1
+if [[ -n "$hg_repo" ]]; then
+    shift
+fi
+
+if [[ -z "$hg_repo" ]]; then
+    echo "usage: $(basename "$0") [-t|--tip] [-r REVS|--rev REVS] HG_REPO"
+    exit 255
+fi
+
+git-push-to-hg $tip_cmd "$hg_repo" "$revs"
+
+hg -R "$hg_repo" push -f -r tip ssh://reviewboard-hg.mozilla.org/autoreview
+echo
+echo "https://treeherder.mozilla.org/#/jobs?repo=try&revision=$(hg -R "$hg_repo" log -l1 --template "{node|short}")"
+
+hg -R "$hg_repo" -q qpop -a > /dev/null


### PR DESCRIPTION
This patch adds push-to-mozreview command, which allows use
moz-git-tools to send patches to mozreview. It works in the same way as
push-to-hg.