### PR TITLE
Skip blank lines at the start of HG patches.

### DIFF
--- a/hg-patch-to-git-patch
+++ b/hg-patch-to-git-patch
@@ -20,9 +20,15 @@ from cStringIO import StringIO
 def hg_patch_to_git_patch(hg_patch_file):
     hg_patch = hg_patch_file.read().split('\n')
 
+    # First, skip any blank lines.
+    for i in range(len(hg_patch)):
+        line = hg_patch[i]
+        if line != "":
+            break
+
     author = None
     date = None # not currently used
-    for i in range(len(hg_patch)):
+    for i in range(i, len(hg_patch)):
         line = hg_patch[i]
         if not line.startswith('#'):
             break


### PR DESCRIPTION
This helps parsing commits downloaded from `https://hg.mozilla.org/.../raw-rev/...`.

gps pointed out in https://bugzilla.mozilla.org/show_bug.cgi?id=1310553 that this blank line is allowed.